### PR TITLE
Remove additional `\r\n` from handshake message

### DIFF
--- a/src/stratus.gleam
+++ b/src/stratus.gleam
@@ -570,8 +570,9 @@ pub fn close(conn: Connection) -> Result(Nil, SocketReason) {
 }
 
 fn make_upgrade(req: Request(String)) -> BytesBuilder {
-  let user_headers = case list.length(req.headers) > 0 {
-    True ->
+  let user_headers = case req.headers {
+    [] -> ""
+    _ ->
       req.headers
       |> list.filter(fn(pair) {
         let #(key, _value) = pair
@@ -587,7 +588,6 @@ fn make_upgrade(req: Request(String)) -> BytesBuilder {
       })
       |> string.join("\r\n")
       |> string.append("\r\n")
-    False -> ""
   }
 
   let path = case req.path {

--- a/src/stratus.gleam
+++ b/src/stratus.gleam
@@ -570,22 +570,25 @@ pub fn close(conn: Connection) -> Result(Nil, SocketReason) {
 }
 
 fn make_upgrade(req: Request(String)) -> BytesBuilder {
-  let user_headers =
-    req.headers
-    |> list.filter(fn(pair) {
-      let #(key, _value) = pair
-      key != "host"
-      && key != "upgrade"
-      && key != "connection"
-      && key != "sec-websocket-key"
-      && key != "sec-websocket-version"
-    })
-    |> list.map(fn(pair) {
-      let #(key, value) = pair
-      key <> ": " <> value
-    })
-    |> string.join("\r\n")
-    |> string.append("\r\n")
+  let user_headers = case list.length(req.headers) > 0 {
+    True ->
+      req.headers
+      |> list.filter(fn(pair) {
+        let #(key, _value) = pair
+        key != "host"
+        && key != "upgrade"
+        && key != "connection"
+        && key != "sec-websocket-key"
+        && key != "sec-websocket-version"
+      })
+      |> list.map(fn(pair) {
+        let #(key, value) = pair
+        key <> ": " <> value
+      })
+      |> string.join("\r\n")
+      |> string.append("\r\n")
+    False -> ""
+  }
 
   let path = case req.path {
     "" -> "/"


### PR DESCRIPTION
This fixes an issue I was seeing when trying to use the [example code](https://github.com/rawhat/stratus/blob/f0d775095045e1284cd7385417c87a3e6f0a1221/README.md) to connect to some websocket test servers. The connection would be established but would then be immediately dropped producing some cryptic message:
- `https://echo.websocket.org`: `DEBG WebSocket closing: "unknown opcode 13"`
- `https://ws.postman-echo.com/raw`: `DEBG WebSocket closing: "Control frames must not be fragmented."`

After doing some digging with a [local websocket echo server](https://github.com/jmalloc/echo-server), I found that this additional `\r\n` that was being appended to the request handshake was breaking it, which was caused by `user_headers` being empty.

The code was changed such that no `\r\n` would come from `user_headers` if there were none specified.

Some additional info about my setup when testing this:
- gleam 1.4.1
- OTP 27
- windows 11