### PR TITLE
Custom close codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ pub fn main() {
         stratus.Binary(_msg) -> stratus.continue(state)
         stratus.User(Close) -> {
           let assert Ok(_) =
-            stratus.close_with_reason(conn, stratus.GoingAway(<<"goodbye">>))
+            stratus.close_with_reason(conn, stratus.close_reason_going_away(<<"goodbye">>))
           stratus.stop()
         }
       }

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ pub fn main() {
         stratus.Binary(_msg) -> stratus.continue(state)
         stratus.User(Close) -> {
           let assert Ok(_) =
-            stratus.close_going_away(conn, <<"goodbye!">>)
+            stratus.close(conn, stratus.GoingAway(<<"goodbye!">>))
           stratus.stop()
         }
       }

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ pub fn main() {
         stratus.Binary(_msg) -> stratus.continue(state)
         stratus.User(Close) -> {
           let assert Ok(_) =
-            stratus.close_with_reason(conn, stratus.close_reason_going_away(<<"goodbye">>))
+            stratus.close_going_away(conn, <<"goodbye!">>)
           stratus.stop()
         }
       }

--- a/src/stratus.gleam
+++ b/src/stratus.gleam
@@ -684,6 +684,13 @@ pub type CloseReason {
   MessageTooBig(body: BitArray)
   MissingExtensions(body: BitArray)
   UnexpectedCondition(body: BitArray)
+  /// Usually used for `4000` codes.
+  CustomCloseReason(
+    /// If `code > 5000`, then it will be treated like a `Normal` close reason.
+    /// See https://hexdocs.pm/gramps/gramps/websocket.html#CloseReason.
+    code: Int,
+    body: BitArray,
+  )
 }
 
 fn convert_close_reason(reason: CloseReason) -> websocket.CloseReason {
@@ -697,6 +704,7 @@ fn convert_close_reason(reason: CloseReason) -> websocket.CloseReason {
     ProtocolError(body:) -> websocket.ProtocolError(body:)
     UnexpectedCondition(body:) -> websocket.UnexpectedCondition(body:)
     UnexpectedDataType(body:) -> websocket.UnexpectedDataType(body:)
+    CustomCloseReason(code:, body:) -> websocket.CustomCloseReason(code:, body:)
   }
 }
 


### PR DESCRIPTION
See https://github.com/rawhat/gramps/pull/3. 

In essence, in addition to the standard 1000 close codes, APIs can define their own. This PR brings things up to date with the gramps PR.

Note: PR is a draft because it currently has a git dependency on my fork. Will change once gramps PR is approved and pushed to Hex.